### PR TITLE
Fix docker image glibc errors

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -37,13 +37,13 @@ jobs:
 
           cd build/deploy
           docker buildx build \
-                --output type=docker,dest=./cockroachdb.tar \
+                --load \
                 --platform linux/amd64 \
                 --progress plain \
                 --tag "v-sekai/cockroach" .
 
-          # Import in local registry
-          docker import cockroachdb.tar cockroach
+          # Export from local registry
+          docker save -o cockroachdb.tar v-sekai/cockroach
 
           echo "BUILD_URL=$BUILD_URL" >> $GITHUB_OUTPUT
 
@@ -58,7 +58,8 @@ jobs:
           body: |
             **CockroachDB** image generated from ${{ steps.build.outputs.BUILD_URL }}
 
-            You can load it with ```docker import cockroachdb.tar cockroach```
+            You can load it in local registry with ```docker load -i cockroachdb.tar```
+            To deploy the loaded image, edit docker compose to use `v-sekai/cockroach`
           draft: false
           prerelease: false
           

--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -1,14 +1,18 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM fedora:41
+RUN dnf update -y && dnf install -y tar gzip xz tzdata hostname && dnf clean all
+# ubi10 is required because oxide-computer builds require glibc 2.35 minimum
+# Replace with line below when ubi10 minimal exits beta and uncomment microdnf commands
+# FROM registry.access.redhat.com/ubi10/ubi-minimal
 
 # For deployment, we need the following additionally installed:
 # tzdata - for time zone functions; reinstalled to replace the missing
 #          files in /usr/share/zoneinfo/
 # hostname - used in cockroach k8s manifests
 # tar - used by kubectl cp
-RUN microdnf update -y \
-    && rpm --erase --nodeps tzdata \
-    && microdnf install tzdata hostname tar gzip xz -y \
-    && rm -rf /var/cache/yum
+#RUN microdnf update -y \
+#    && rpm --erase --nodeps tzdata \
+#    && microdnf install tzdata hostname tar gzip xz -y \
+#    && rm -rf /var/cache/yum
 
 RUN mkdir /usr/local/lib/cockroach /cockroach /licenses /docker-entrypoint-initdb.d
 COPY cockroach.sh cockroach /cockroach/


### PR DESCRIPTION
Docker image ubi8 runs an older glibc version, so it can't run oxide-computer cockroach build.
I changed base image to fedora 41 and tested with docker compose.