### PR TITLE
Use go-version-file to match go.mod toolchain requirement

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -32,10 +32,10 @@ jobs:
             libncurses-dev libbz2-dev libsnappy-dev \
             clang lld bison
 
-      - name: Set up Go 1.17
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.17"
+          go-version-file: "go.mod"
           cache: false
 
       - name: Build cockroachoss + GEOS
@@ -84,10 +84,10 @@ jobs:
           echo "C:/tools/nodejs" >> $GITHUB_PATH
           echo "C:/ProgramData/mingw64/mingw64/bin" >> $GITHUB_PATH
 
-      - name: Set up Go 1.17
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.17"
+          go-version-file: "go.mod"
           cache: false
 
       - name: Build cockroachoss.exe


### PR DESCRIPTION
## Summary

- `go.mod` declares `go 1.22.1` / `toolchain go1.22.11` but the workflow was pinning `go-version: "1.17"`
- Go 1.17 cannot parse the `toolchain` directive, causing `go: errors parsing go.mod` and `make: *** [Makefile:329: vendor/modules.txt] Error 1` on every build
- Switch both jobs to `go-version-file: "go.mod"` so the installed Go always matches whatever the module requires

## Test plan

- [ ] CI run on this PR passes the "Build cockroachoss + GEOS" step without the go.mod parse error