### PR TITLE
ci: package the Windows build as a signed MSIX

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -112,6 +112,50 @@ jobs:
           path: cockroachoss.exe
           if-no-files-found: error
 
+  msix:
+    name: Package Windows MSIX
+    needs: build-windows
+    runs-on: windows-latest
+    # Set secrets COCKROACH_PFX_BASE64 + COCKROACH_PFX_PASSWORD for a trusted
+    # cert; without them the package self-signs a TEST cert (installable only
+    # after trusting it).
+    env:
+      COCKROACH_PFX_BASE64: ${{ secrets.COCKROACH_PFX_BASE64 }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Windows binary
+        uses: actions/download-artifact@v4
+        with:
+          name: cockroach-windows-amd64
+          path: winbin
+
+      - name: Stage binary as cockroach.exe
+        shell: bash
+        run: |
+          mkdir -p bin
+          cp winbin/cockroachoss.exe bin/cockroach.exe
+          cp winbin/*.dll bin/ 2>/dev/null || true
+          ls -l bin
+
+      - name: Import signing cert
+        if: ${{ env.COCKROACH_PFX_BASE64 != '' }}
+        shell: bash
+        run: echo "$COCKROACH_PFX_BASE64" | base64 -d > cockroach.pfx
+
+      - name: Pack + sign MSIX
+        shell: pwsh
+        run: |
+          $pfx = if (Test-Path cockroach.pfx) { @("-PfxPath","cockroach.pfx","-PfxPassword","${{ secrets.COCKROACH_PFX_PASSWORD }}") } else { @() }
+          pwsh packaging/msix/pack.ps1 -BinDir bin -Version "22.1.0.${{ github.run_number }}" -OutDir dist @pfx
+
+      - name: Upload MSIX
+        uses: actions/upload-artifact@v4
+        with:
+          name: cockroach-msix
+          path: dist/*.msix
+          if-no-files-found: error
+
   manifest:
     name: Create multi-arch manifest
     runs-on: ubuntu-latest

--- a/packaging/msix/AppxManifest.xml
+++ b/packaging/msix/AppxManifest.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Identity/Publisher must match the signing cert subject; Version is 4-part.
+     pack.ps1 patches Version and Publisher before packing. CockroachDB is a
+     console server, so it's wrapped as a full-trust Win32 app. -->
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap rescap">
+
+  <Identity
+    Name="v-sekai.CockroachDB"
+    Publisher="CN=v-sekai"
+    Version="22.1.0.0"
+    ProcessorArchitecture="x64" />
+
+  <Properties>
+    <DisplayName>CockroachDB (v-sekai)</DisplayName>
+    <PublisherDisplayName>v-sekai</PublisherDisplayName>
+    <Logo>assets\StoreLogo.png</Logo>
+    <Description>CockroachDB distributed SQL server (v-sekai fork) — experimental Windows build.</Description>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.22621.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="en-us" />
+  </Resources>
+
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+
+  <Applications>
+    <Application Id="Cockroach" Executable="bin\cockroach.exe" EntryPoint="Windows.FullTrustApplication">
+      <uap:VisualElements
+        DisplayName="CockroachDB (v-sekai)"
+        Description="CockroachDB distributed SQL server CLI: start, start-single-node, sql, init"
+        BackgroundColor="transparent"
+        Square150x150Logo="assets\Square150x150Logo.png"
+        Square44x44Logo="assets\Square44x44Logo.png" />
+    </Application>
+  </Applications>
+</Package>

--- a/packaging/msix/README.md
+++ b/packaging/msix/README.md
@@ -1,0 +1,34 @@
+# Windows MSIX packaging
+
+Wraps the v-sekai CockroachDB **Windows** build into a signed MSIX.
+
+CockroachDB does not ship a supported Windows server build, but this fork
+already cross/native-builds a Windows binary in
+`.github/workflows/build-docker.yml` (`build-windows` job →
+`make cockroachoss XGOOS=windows …`, uploaded as the `cockroach-windows-amd64`
+artifact). The `msix` job in that workflow stages the binary as `cockroach.exe`
+and runs `pack.ps1` to emit a signed `.msix`.
+
+## Local use
+
+From a Windows machine with the Windows SDK installed (provides
+`makeappx.exe` / `signtool.exe`):
+
+```powershell
+# bin/ must contain cockroach.exe (+ optional libgeos*.dll)
+pwsh packaging/msix/pack.ps1 -BinDir bin -Version 22.1.0.0
+```
+
+- Without `-PfxPath`, a **self-signed TEST cert** is generated; the resulting
+  MSIX only installs after you trust that cert (import into
+  *Local Machine → Trusted People*, then `Add-AppxPackage …`).
+- With a real cert: `-PfxPath your.pfx -PfxPassword <pw>`. The cert subject
+  **must** equal the manifest `Publisher` (default `CN=v-sekai`).
+
+## Notes
+
+- The console server is wrapped as a full-trust Win32 app (`runFullTrust`).
+- Logo assets are generated as solid-colour placeholders at pack time if no
+  PNGs are committed under `assets/`, keeping this packaging text-only.
+- Windows is an **experimental** CockroachDB target; this is intended for
+  local/dev use, not production. Linux (rpm/deb/container) remains primary.

--- a/packaging/msix/pack.ps1
+++ b/packaging/msix/pack.ps1
@@ -1,0 +1,92 @@
+<#
+  Build + sign the CockroachDB MSIX from an already-built Windows binary.
+  Requires Windows + Windows SDK (makeappx.exe, signtool.exe).
+
+  The v-sekai fork produces a Windows binary via build-docker.yml's
+  `build-windows` job (`make cockroachoss XGOOS=windows ...`, uploaded as the
+  `cockroach-windows-amd64` artifact). Stage that exe (renamed cockroach.exe),
+  plus any libgeos DLLs, into -BinDir and run this script.
+
+  -BinDir   folder with cockroach.exe (+ optional libgeos*.dll)
+  -Version  4-part version, e.g. 22.1.0.0
+  -OutDir   output dir (default dist)
+  -Publisher Identity Publisher; MUST equal the signing cert subject (default CN=v-sekai)
+  -PfxPath  signing .pfx; if omitted a self-signed TEST cert is generated (test-install only)
+  -PfxPassword  .pfx password, if any
+
+  ex: pwsh packaging/msix/pack.ps1 -BinDir bin -Version 22.1.0.0
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)] [string]$BinDir,
+  [string]$Version  = "22.1.0.0",
+  [string]$OutDir   = "dist",
+  [string]$Publisher = "CN=v-sekai",
+  [string]$PfxPath,
+  [string]$PfxPassword
+)
+$ErrorActionPreference = "Stop"
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+if (-not (Test-Path "$BinDir\cockroach.exe")) {
+  throw "cockroach.exe not found in '$BinDir'. Stage the Windows build there first."
+}
+
+$sdk = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Directory |
+       Where-Object { Test-Path "$($_.FullName)\x64\makeappx.exe" } |
+       Sort-Object Name -Descending | Select-Object -First 1
+if (-not $sdk) { throw "Windows SDK with makeappx.exe not found." }
+$makeappx = "$($sdk.FullName)\x64\makeappx.exe"
+$signtool = "$($sdk.FullName)\x64\signtool.exe"
+
+$root = Join-Path ([System.IO.Path]::GetTempPath()) ("cockroach-msix-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Force -Path "$root\bin","$root\assets" | Out-Null
+Copy-Item "$BinDir\*" "$root\bin\" -Recurse
+
+# Visual assets: use committed PNGs if present, otherwise generate solid-colour
+# placeholders so the package is self-contained without binary blobs in git.
+$assetSrc = Join-Path $here "assets"
+$logos = @{ "Square44x44Logo.png" = 44; "Square150x150Logo.png" = 150; "StoreLogo.png" = 50 }
+foreach ($name in $logos.Keys) {
+  $src = Join-Path $assetSrc $name
+  $dst = Join-Path "$root\assets" $name
+  if (Test-Path $src) { Copy-Item $src $dst; continue }
+  $size = $logos[$name]
+  try {
+    Add-Type -AssemblyName System.Drawing
+    $bmp = New-Object System.Drawing.Bitmap($size, $size)
+    $g = [System.Drawing.Graphics]::FromImage($bmp)
+    $g.Clear([System.Drawing.Color]::FromArgb(255, 105, 51, 255))  # cockroach-ish purple
+    $g.Dispose()
+    $bmp.Save($dst, [System.Drawing.Imaging.ImageFormat]::Png)
+    $bmp.Dispose()
+  } catch {
+    # Fallback: minimal 1x1 PNG if GDI+ is unavailable.
+    $png1x1 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNgQAcAAA0AAekHHr0AAAAASUVORK5CYII="
+    [IO.File]::WriteAllBytes($dst, [Convert]::FromBase64String($png1x1))
+  }
+}
+
+[xml]$m = Get-Content "$here\AppxManifest.xml"
+$m.Package.Identity.Version   = $Version
+$m.Package.Identity.Publisher = $Publisher
+$m.Save("$root\AppxManifest.xml")
+
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+$msix = Join-Path $OutDir "v-sekai-cockroach-$Version.msix"
+& $makeappx pack /o /d $root /p $msix
+if ($LASTEXITCODE) { throw "makeappx failed ($LASTEXITCODE)" }
+
+if (-not $PfxPath) {
+  $cert = New-SelfSignedCertificate -Type Custom -Subject $Publisher `
+            -KeyUsage DigitalSignature -CertStoreLocation "Cert:\CurrentUser\My" `
+            -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3","2.5.29.19={text}")
+  $PfxPath = Join-Path $OutDir "cockroach-test.pfx"; $PfxPassword = "test"
+  Export-PfxCertificate -Cert $cert -FilePath $PfxPath `
+    -Password (ConvertTo-SecureString $PfxPassword -AsPlainText -Force) | Out-Null
+}
+$pwArgs = if ($PfxPassword) { @("/p", $PfxPassword) } else { @() }
+& $signtool sign /fd SHA256 /a /f $PfxPath @pwArgs $msix
+if ($LASTEXITCODE) { throw "signtool failed ($LASTEXITCODE)" }
+
+Write-Host "OK -> $msix"


### PR DESCRIPTION
## What

Adds **Windows MSIX packaging** for the fork, building on the existing `build-windows` job (which already produces `cockroachoss.exe` via `make cockroachoss XGOOS=windows …`).

- `packaging/msix/AppxManifest.xml` — full-trust (`runFullTrust`) Win32 wrapper for the console server, identity `v-sekai.CockroachDB`.
- `packaging/msix/pack.ps1` — stages `cockroach.exe` (+ any `libgeos*.dll`), patches version/publisher, `makeappx pack` + `signtool sign`. Self-signs a TEST cert when no `.pfx` is provided, and generates solid-colour placeholder logos so this PR stays **text-only** (no binary blobs).
- `packaging/msix/README.md` — local + CI usage.
- New **`msix`** job in `build-docker.yml`: `needs: build-windows` → downloads the `cockroach-windows-amd64` artifact → packs → uploads `cockroach-msix`.

## Why

CockroachDB has no supported native Windows build, and the source cannot even `go build` without Bazel codegen — so we cannot use upstream binaries or a naive cross-compile. This wires packaging onto **the fork''s own Windows binary**, the only artifact we control.

## Notes / follow-ups

- Signing: set repo secrets `COCKROACH_PFX_BASE64` + `COCKROACH_PFX_PASSWORD` for a trusted cert; otherwise the MSIX self-signs (installable after trusting the cert).
- Windows is an **experimental** CockroachDB target — intended for local/dev use. Linux (rpm/deb/container) remains primary.
- The `msix` job only runs if `build-windows` is green; this PR does not change that job.